### PR TITLE
Entity cleanup

### DIFF
--- a/lib/entity-constructor.js
+++ b/lib/entity-constructor.js
@@ -1,21 +1,32 @@
 /*
-    Everything related to entities
+    Everything related to entities.
+
+    This file defines entities, data associated with how they are represented and
+    connected to other objects, and actions they can perform, such as on drag and 
+    click events.
 */
 
-/***** Entity property definitions *****/
+/***** Global definitions *****/
 
+// Entity appearance and behavior
 var entity_param = {
     width : 100,
     height : 50,
     snapTolerance : 8
 };
 
+// Distance tolerances for snap and link events
 var tolerance;
 tolerance.link["entity"] = entity_param.width ;
 tolerance.snap["entity"] = entity_param.snapTolerance ;
 
-var svg;
-var orm;
+// Graph variables
+var svg; // Defined in svg-constructor
+var orm; // Defined in graph-constructor
+
+/***** END Global definitions *****/
+
+/***** Entity IDS *****/
 
 function generate_entityID() {
     entityID = "id-entity-" + orm.highestEntityID.toString();
@@ -51,16 +62,16 @@ function entityID_from_overlayID(oentityID) {
            oentityID.split("-")[3];
 }
 
-/***** END Entity property definitions *****/
+/***** END Entity IDs *****/
 
 /*****  Drawing entities *****/
 
 function entity_definition(x,y,entityID) {
 
+    // Definition of how an entity looks
+
     var width = entity_param.width;
     var height = entity_param.height;
-    var tx = x - width/2;
-    var ty = y - height/2;
     var ename = "Entity "+entity_number(entityID);
 
     // Create a group for the rect / text
@@ -116,6 +127,7 @@ function draw_entity(x,y) {
     orm.entities[entityID] = entity;
 
     // Create new overlay for entity
+    // Overlays are defined in graph-constructor
     var overlay = overlay_definition(entity,"eoverlay");
     var overlayID = overlay.attr("id");
 
@@ -132,12 +144,12 @@ function draw_entity(x,y) {
 function entity_actions(entity) {
 
     // What to do on drag event
-
     var drag_entity = d3.drag()
         .on("start", edragstarted)
         .on("drag", function (event,d) { edragged(event,d, entity.attr("id") ) } )
         .on("end", edragended);
 
+    // Add events to the entity
     entity
         .on("dblclick", function(event) { event.stopPropagation() })
         .on("click", remove_entity)
@@ -226,7 +238,7 @@ function edragended() {
     parse_orm();
 }
 
-/* On mouse up and down for the entity overlay circles */
+/* On mouse down for the entity overlay circles */
 
 function eomousedown(event) {
     
@@ -286,6 +298,6 @@ function eoverlay_positions(entityID) {
     return xyoverlay;
 }
 
-/* END On mouse up and down for the entity overlay circles */
+/* END On mouse up for the entity overlay circles */
 
 /***** END  Drag control for the entity *****/

--- a/lib/entity-constructor.js
+++ b/lib/entity-constructor.js
@@ -7,7 +7,7 @@
 var entity_param = {
     width : 100,
     height : 50,
-    snapTolerance : 15
+    snapTolerance : 8
 };
 
 var tolerance;
@@ -56,9 +56,9 @@ function entityID_from_overlayID(oentityID) {
 /*****  Drawing entities *****/
 
 
-function entity_translate(x,y) {
-    var tx = x - entity_param.width/2;
-    var ty = y - entity_param.height/2;
+function object_translate(x,y,width,height) {
+    var tx = x - width/2;
+    var ty = y - height/2;
     return "translate( " + tx + "," + ty + " )"
 }
 
@@ -74,10 +74,12 @@ function entity_definition(x,y,entityID) {
     var entity = svg.append("g")
         .datum( {x: x, y: y, dx: 0, dy: 0, x0: x, y0: y,
                 selected: false, kind: "entity",
+                overlay: overlay_from_ID(entityID),
                 relationships: [],
                 name: ename} )
         .attr("class","entity_prototype")
         .attr("id",entityID)
+        .attr("parent",entityID) // This is used for the overlay definitions
         .attr("x", function(){ return (x) })
         .attr("y", function(){ return (y) })
         .attr("width", width)
@@ -105,42 +107,47 @@ function entity_definition(x,y,entityID) {
 
 }
 
-function eoverlay_definition(entity) {
-    var width = entity_param.width;
-    var height = entity_param.height;
+function overlay_definition(object,oclass) {
+    //var width = entity_param.width;
+    //var height = entity_param.height;
 
-    var overlayID = overlay_from_ID(entity.attr("id"));
-    var d = entity.datum();
+    var width = object.attr("width");
+    var height = object.attr("height");
 
-    var overlay = entity.append("g")
+    var d = object.datum();
+    var pd = d3.select("#" + object.attr("parent") ).datum();
+    var overlayID = d.overlay;
+
+    var x = pd.x0 + d.dx;
+    var y = pd.y0;
+
+    var tr = d3.select("#r-"+object.attr("id")).attr("transform");
+
+    var overlay = object.append("g")
         .attr("id", overlayID)
-        .attr("class","entity_overlay_prototype")
-        .attr("x", d.x)
-        .attr("y", d.y)
-        .attr("transform", function() { return entity_translate(d.x,d.y); });
+        .attr("class","overlay_prototype")
+        .attr("width", width)
+        .attr("height", height)
+        .attr("x", 0)
+        .attr("y", 0)
+        //.attr("transform",tr);
+        .attr("transform", function() { return object_translate(x,y,width,height); });
+        //.attr("transform", function() { return object.attr("transform") });
     // Right circle overlay
     overlay.append("circle")
-        .attr("class","eoverlay overlay")
-        .attr("x", d.x)
-        .attr("y", d.y)
+        .attr("class","overlay "+oclass)
         .attr("transform", "translate( " + width/2 + " " + 0 + " )");
     // Right circle overlay
     overlay.append("circle")
-        .attr("class","overlay eoverlay")
-        .attr("x", d.x)
-        .attr("y", d.y)
+        .attr("class","overlay "+oclass)
         .attr("transform", "translate( " + width + " " + height/2 + " )");
     // Bottom circle overlay
     overlay.append("circle")
-        .attr("class","overlay eoverlay")
-        .attr("x", d.x)
-        .attr("y", d.y)
+        .attr("class","overlay "+oclass)
         .attr("transform", "translate( " + width/2 + " " + height + " )");
     // Top circle overlay
     overlay.append("circle")
-        .attr("class","overlay eoverlay")
-        .attr("x", d.x)
-        .attr("y", d.y)
+        .attr("class","overlay "+oclass)
         .attr("transform", "translate( " + 0 + " " + height/2 + " )");
     
     return overlay;
@@ -244,7 +251,8 @@ function draw_entity(x,y) {
        .attr("x", function(d){ return (x) })
        .attr("y", function(d){ return (y) });*/
 
-    var overlay = eoverlay_definition(entity);
+    //var ebox = d3.select("#r-"+entity.attr("id"));
+    var overlay = overlay_definition(entity,"eoverlay");
 
     overlay_actions(overlay);
 
@@ -338,6 +346,7 @@ function edragged(event,d,entityID) {
     d.y = d.y0 + d.dy;
 
     // Drag entity
+    // Need transform on group as long as we can't use prototype
     var entity = d3.select("#"+entityID);
     entity.attr("x", d.x )
           .attr("y", d.y )

--- a/lib/entity-constructor.js
+++ b/lib/entity-constructor.js
@@ -9,6 +9,7 @@
 /***** Global definitions *****/
 
 // Entity appearance and behavior
+// TO DO: Pull from css
 var entity_param = {
     width : 100,
     height : 50,
@@ -141,6 +142,10 @@ function draw_entity(x,y) {
 
 }
 
+/***** END Drawing entities *****/
+
+/***** Entity actions *****/
+
 function entity_actions(entity) {
 
     // What to do on drag event
@@ -192,8 +197,6 @@ function delete_entity(entity) {
     delete orm.entities[ entityID ];
     delete orm.eoverlays[ overlay_from_ID(entityID) ];
 }
-
-/***** END  Drawing entities *****/
 
 /*****  Drag control for the entity *****/
 
@@ -301,3 +304,5 @@ function eoverlay_positions(entityID) {
 /* END On mouse up for the entity overlay circles */
 
 /***** END  Drag control for the entity *****/
+
+/***** END Entity actions *****/

--- a/lib/entity-constructor.js
+++ b/lib/entity-constructor.js
@@ -82,7 +82,6 @@ function entity_definition(x,y,entityID) {
         .attr("y", function(){ return (y) })
         .attr("width", width)
         .attr("height", height);
-        //.attr("transform", function(d){ return entity_translate(d.x,d.y); } );
     // Entity rectangle
     entity.append("rect")
         .attr("class","entity")
@@ -146,10 +145,10 @@ function eoverlay_definition(entity) {
     
     return overlay;
 }
-
+/*
 function entity_prototype(defs) {
     
-    /* Define the look of an entity */
+    // Define the look of an entity
 
     var width = entity_param.width;
     var height = entity_param.height;
@@ -168,7 +167,7 @@ function entity_prototype(defs) {
      .attr("text-anchor", "middle")
      .attr("dominant-baseline", "central");
      //.text(function(d) { return d; });*/
-
+/*
     var go = create_group(defs,width,height,"entity_overlay_prototype");
     // Top circle overlay
     go.append("circle")
@@ -186,7 +185,7 @@ function entity_prototype(defs) {
     go.append("circle")
       .attr("class","overlay eoverlay")
       .attr("transform", "translate( " + 0 + " " + height/2 + " )");
-}
+}*/
 
 function draw_entity(x,y) {
 
@@ -196,7 +195,6 @@ function draw_entity(x,y) {
     var entityID = generate_entityID();
 
     // Add the visualization of the entity
-    console.log(x,y)
     var entity = entity_definition(x,y,entityID);
 
     /* With prototype. Want to use this, but need custom text in prototype.
@@ -360,12 +358,12 @@ function edragged(event,d,entityID) {
     entity.attr("x", d.x).attr("y", d.y);
     d3.select("#t-"+entityID)
           .attr("x", d.x).attr("y", d.y)
-          //.attr("transform", function(d){ return entity_translate(d.x,d.y); } );
     //console.log( d3.select("#t-"+entityID) )*/
 
+    /*
     // Drag the circle overlays
     d3.select("#"+overlay_from_ID(entityID))
-      .attr("x", d.x).attr("y", d.y);
+      .attr("x", d.x).attr("y", d.y);*/
     
     // Drag all connected relations
     for (var n in d.relationships) {
@@ -387,13 +385,18 @@ function eomousedown(event) {
     
     event.stopPropagation();
 
+    // Get entity
+    var entityID = entityID_from_overlayID( d3.select(this).attr("id") );
+    var d = orm.entities[entityID].datum();
+
     // current pointer position
     var m = d3.pointer(event);
-    var mousepos = {x: m[0], y: m[1]};
+    var mousepos = {x: m[0] + d.x - entity_param.width/2, 
+                    y: m[1] + d.y - entity_param.height/2};
+    console.log(m, mousepos);
 
     // Center of closest entity overlay
-    entityID = entityID_from_overlayID( d3.select(this).attr("id") );
-    eo = closest_eoverlay(mousepos, entityID);
+    var eo = closest_eoverlay(mousepos, entityID);
 
     var rel = draw_rel_line(eo.x, eo.y, mousepos.x, mousepos.y);
     rel.datum().from = entityID;

--- a/lib/entity-constructor.js
+++ b/lib/entity-constructor.js
@@ -55,11 +55,11 @@ function entityID_from_overlayID(oentityID) {
 
 /*****  Drawing entities *****/
 
-/*
+
 function entity_translate(x,y) {
     var tx = x - entity_param.width/2;
     var ty = y - entity_param.height/2;
-    return "translate( " + tx + " " + ty + " )"
+    return "translate( " + tx + "," + ty + " )"
 }
 
 function entity_definition(x,y,entityID) {
@@ -68,32 +68,84 @@ function entity_definition(x,y,entityID) {
     var height = entity_param.height;
     var tx = x - width/2;
     var ty = y - height/2;
+    var ename = "Entity "+entity_number(entityID);
+
     // Create a group for the rect / text
-    var g = svg.append("g")
-        .datum( {x: x, y: y, selected: false, kind: "entity",
-            relationships: [],
-            name: "Entity "+entity_number(entityID)} )
+    var entity = svg.append("g")
+        .datum( {x: x, y: y, dx: 0, dy: 0, x0: x, y0: y,
+                selected: false, kind: "entity",
+                relationships: [],
+                name: ename} )
+        .attr("class","entity_prototype")
         .attr("id",entityID)
-        .attr("x", function(d){ return (d.x) })
-        .attr("y", function(d){ return (d.y) })
+        .attr("x", function(){ return (x) })
+        .attr("y", function(){ return (y) })
         .attr("width", width)
-        .attr("height", height)
-        .attr("transform", function(d){ return entity_translate(d.x,d.y); } );
+        .attr("height", height);
+        //.attr("transform", function(d){ return entity_translate(d.x,d.y); } );
     // Entity rectangle
-    g.append("rect")
-     .attr("class","entity");
+    entity.append("rect")
+        .attr("class","entity")
+        .attr("id","r-"+entityID)
+        .attr("x", function(){ return (x) })
+        .attr("y", function(){ return (y) })
+        .attr("transform", "translate( -" + entity_param.width/2 + 
+                                     " -" + entity_param.height/2 + " )");
     // Display entity name
-    g.append("text")
-     .attr("class","ename")
-     .attr("transform", "translate( " + width/2 + " " + height/2 + " )")
-     .attr("text-anchor", "middle")
-     .attr("dominant-baseline", "central")
-     .text(function(d) { return d.name; });
+    entity.append("text")
+        .attr("class","ename")
+        .attr("id","t-"+entityID)
+        //.attr("transform", "translate( " + width/2 + " " + height/2 + " )")
+        .attr("x", function(){ return (x) })
+        .attr("y", function(){ return (y) })
+        .attr("text-anchor", "middle")
+        .attr("dominant-baseline", "central")
+        .text( function(d){ return d.name } );
     
-    return g;
+    return entity;
 
 }
-*/
+
+function eoverlay_definition(entity) {
+    var width = entity_param.width;
+    var height = entity_param.height;
+
+    var overlayID = overlay_from_ID(entity.attr("id"));
+    var d = entity.datum();
+
+    var overlay = entity.append("g")
+        .attr("id", overlayID)
+        .attr("class","entity_overlay_prototype")
+        .attr("x", d.x)
+        .attr("y", d.y)
+        .attr("transform", function() { return entity_translate(d.x,d.y); });
+    // Right circle overlay
+    overlay.append("circle")
+        .attr("class","eoverlay overlay")
+        .attr("x", d.x)
+        .attr("y", d.y)
+        .attr("transform", "translate( " + width/2 + " " + 0 + " )");
+    // Right circle overlay
+    overlay.append("circle")
+        .attr("class","overlay eoverlay")
+        .attr("x", d.x)
+        .attr("y", d.y)
+        .attr("transform", "translate( " + width + " " + height/2 + " )");
+    // Bottom circle overlay
+    overlay.append("circle")
+        .attr("class","overlay eoverlay")
+        .attr("x", d.x)
+        .attr("y", d.y)
+        .attr("transform", "translate( " + width/2 + " " + height + " )");
+    // Top circle overlay
+    overlay.append("circle")
+        .attr("class","overlay eoverlay")
+        .attr("x", d.x)
+        .attr("y", d.y)
+        .attr("transform", "translate( " + 0 + " " + height/2 + " )");
+    
+    return overlay;
+}
 
 function entity_prototype(defs) {
     
@@ -120,7 +172,7 @@ function entity_prototype(defs) {
     var go = create_group(defs,width,height,"entity_overlay_prototype");
     // Top circle overlay
     go.append("circle")
-      .attr("class","overlay eoverlay")
+      .attr("class","eoverlay overlay")
       .attr("transform", "translate( " + width/2 + " " + 0 + " )");
     // Right circle overlay
     go.append("circle")
@@ -144,13 +196,11 @@ function draw_entity(x,y) {
     var entityID = generate_entityID();
 
     // Add the visualization of the entity
-    /* Not using entity_definition rn
+    console.log(x,y)
     var entity = entity_definition(x,y,entityID);
-    entity.on("click", remove_entity)
-          .call(drag);*/
 
     /* With prototype. Want to use this, but need custom text in prototype.
-       Creating group and appending text instead. */
+       Creating group and appending text instead.
     var ename = "Entity "+entity_number(entityID);
     var entity = svg.append("g")
         .datum( {x: x, y: y, selected: false, kind: "entity",
@@ -176,7 +226,7 @@ function draw_entity(x,y) {
         .attr("text-anchor", "middle")
         .attr("dominant-baseline", "central")
         .attr("pointer-events","none")
-        .text( ename );
+        .text( ename ); */
 
     entity_actions(entity);
 
@@ -187,14 +237,20 @@ function draw_entity(x,y) {
 
     var overlayID = overlay_from_ID(entityID);
     
+    /*
     var overlay = svg.append("use")
        .datum( {x: x, y: y, selected: false} )
        .attr("href","#entity_overlay_prototype")
+       .attr("class","overlay eoverlay")
        .attr("id", overlayID)
        .attr("x", function(d){ return (x) })
-       .attr("y", function(d){ return (y) });
+       .attr("y", function(d){ return (y) });*/
+
+    var overlay = eoverlay_definition(entity);
 
     overlay_actions(overlay);
+
+    //entity.append(overlay);
     
     // Record overlay
     orm.eoverlays[overlayID] = overlay;
@@ -221,7 +277,10 @@ function entity_actions(entity) {
 }
 
 function overlay_actions(eoverlay) {
-    eoverlay.on("mousedown", eomousedown );
+    eoverlay.on("mousedown", eomousedown )
+            .on("hover", function() { 
+                this.attr("fill-opacity", "1.0");
+                console.log("opacity") });
 }
 
 // Removing entities on click events
@@ -271,6 +330,23 @@ function edragstarted(event) {
 function edragged(event,d,entityID) {
 
     // Set the new position
+    d.dx += event.dx;
+    d.dy += event.dy;
+
+    // Snap to entities
+    d.dx = snap( d.dx + d.x0, "x", entityID ) - d.x0;
+    d.dy = snap( d.dy + d.y0, "y", entityID ) - d.y0;
+    d.x = d.x0 + d.dx;
+    d.y = d.y0 + d.dy;
+
+    // Drag entity
+    var entity = d3.select("#"+entityID);
+    entity.attr("x", d.x )
+          .attr("y", d.y )
+          .attr("transform", "translate("+d.dx+","+d.dy+")");
+
+    /* When using defs for entity
+    // Set the new position
     d.x = event.x;
     d.y = event.y;
 
@@ -283,9 +359,9 @@ function edragged(event,d,entityID) {
     var entity = d3.select("#r-"+entityID);
     entity.attr("x", d.x).attr("y", d.y);
     d3.select("#t-"+entityID)
-          .attr("x", d.x).attr("y", d.y);
-    //      .attr("transform", function(d){ return entity_translate(d.x,d.y); } );
-    //console.log( d3.select("#t-"+entityID) )
+          .attr("x", d.x).attr("y", d.y)
+          //.attr("transform", function(d){ return entity_translate(d.x,d.y); } );
+    //console.log( d3.select("#t-"+entityID) )*/
 
     // Drag the circle overlays
     d3.select("#"+overlay_from_ID(entityID))
@@ -309,7 +385,7 @@ function edragended() {
 
 function eomousedown(event) {
     
-    //event.sourceEvent.stopPropagation();
+    event.stopPropagation();
 
     // current pointer position
     var m = d3.pointer(event);

--- a/lib/entity-constructor.js
+++ b/lib/entity-constructor.js
@@ -101,7 +101,6 @@ function entity_definition(x,y,entityID) {
     entity.append("text")
         .attr("class","ename")
         .attr("id","t-"+entityID)
-        //.attr("transform", "translate( " + width/2 + " " + height/2 + " )")
         .attr("x", function(){ return (x) })
         .attr("y", function(){ return (y) })
         .attr("text-anchor", "middle")
@@ -121,7 +120,6 @@ function draw_entity(x,y) {
 
     // Add the visualization of the entity
     var entity = entity_definition(x,y,entityID);
-
     entity_actions(entity);
 
     // Record new entity
@@ -130,12 +128,7 @@ function draw_entity(x,y) {
     // Create new overlay for entity
     // Overlays are defined in graph-constructor
     var overlay = overlay_definition(entity,"eoverlay");
-    var overlayID = overlay.attr("id");
-
     overlay_actions(overlay);
-    
-    // Record overlay
-    orm.eoverlays[overlayID] = overlay;
 
     // Update rel
     parse_orm();
@@ -195,7 +188,6 @@ function delete_entity(entity) {
         .remove();
     // Remove the entity from records
     delete orm.entities[ entityID ];
-    delete orm.eoverlays[ overlay_from_ID(entityID) ];
 }
 
 /*****  Drag control for the entity *****/

--- a/lib/entity-constructor.js
+++ b/lib/entity-constructor.js
@@ -55,13 +55,6 @@ function entityID_from_overlayID(oentityID) {
 
 /*****  Drawing entities *****/
 
-
-function object_translate(x,y,width,height) {
-    var tx = x - width/2;
-    var ty = y - height/2;
-    return "translate( " + tx + "," + ty + " )"
-}
-
 function entity_definition(x,y,entityID) {
 
     var width = entity_param.width;
@@ -107,93 +100,6 @@ function entity_definition(x,y,entityID) {
 
 }
 
-function overlay_definition(object,oclass) {
-    //var width = entity_param.width;
-    //var height = entity_param.height;
-
-    var width = object.attr("width");
-    var height = object.attr("height");
-
-    var d = object.datum();
-    var pd = d3.select("#" + object.attr("parent") ).datum();
-    var overlayID = d.overlay;
-
-    var x = pd.x0 + d.dx;
-    var y = pd.y0;
-
-    var tr = d3.select("#r-"+object.attr("id")).attr("transform");
-
-    var overlay = object.append("g")
-        .attr("id", overlayID)
-        .attr("class","overlay_prototype")
-        .attr("width", width)
-        .attr("height", height)
-        .attr("x", 0)
-        .attr("y", 0)
-        //.attr("transform",tr);
-        .attr("transform", function() { return object_translate(x,y,width,height); });
-        //.attr("transform", function() { return object.attr("transform") });
-    // Right circle overlay
-    overlay.append("circle")
-        .attr("class","overlay "+oclass)
-        .attr("transform", "translate( " + width/2 + " " + 0 + " )");
-    // Right circle overlay
-    overlay.append("circle")
-        .attr("class","overlay "+oclass)
-        .attr("transform", "translate( " + width + " " + height/2 + " )");
-    // Bottom circle overlay
-    overlay.append("circle")
-        .attr("class","overlay "+oclass)
-        .attr("transform", "translate( " + width/2 + " " + height + " )");
-    // Top circle overlay
-    overlay.append("circle")
-        .attr("class","overlay "+oclass)
-        .attr("transform", "translate( " + 0 + " " + height/2 + " )");
-    
-    return overlay;
-}
-/*
-function entity_prototype(defs) {
-    
-    // Define the look of an entity
-
-    var width = entity_param.width;
-    var height = entity_param.height;
-    // Create a group for the rect / text
-    // NOTE: Can't use this prototype til I figure out custom text content :(
-    //       Using entity_definition in the meanwhile
-    var g = create_group(defs,width,height,"entity_prototype");
-    // Entity rectangle
-    g.append("rect")
-     .attr("class","entity");
-    // Display entity name (Can't define this here with custom text)
-    /*
-    g.append("text")
-     .attr("class","ename")
-     .attr("transform", "translate( " + width/2 + " " + height/2 + " )")
-     .attr("text-anchor", "middle")
-     .attr("dominant-baseline", "central");
-     //.text(function(d) { return d; });*/
-/*
-    var go = create_group(defs,width,height,"entity_overlay_prototype");
-    // Top circle overlay
-    go.append("circle")
-      .attr("class","eoverlay overlay")
-      .attr("transform", "translate( " + width/2 + " " + 0 + " )");
-    // Right circle overlay
-    go.append("circle")
-      .attr("class","overlay eoverlay")
-      .attr("transform", "translate( " + width + " " + height/2 + " )");
-    // Bottom circle overlay
-    go.append("circle")
-      .attr("class","overlay eoverlay")
-      .attr("transform", "translate( " + width/2 + " " + height + " )");
-    // Left circle overlay
-    go.append("circle")
-      .attr("class","overlay eoverlay")
-      .attr("transform", "translate( " + 0 + " " + height/2 + " )");
-}*/
-
 function draw_entity(x,y) {
 
     // Draw a new instance of an entity
@@ -204,59 +110,16 @@ function draw_entity(x,y) {
     // Add the visualization of the entity
     var entity = entity_definition(x,y,entityID);
 
-    /* With prototype. Want to use this, but need custom text in prototype.
-       Creating group and appending text instead.
-    var ename = "Entity "+entity_number(entityID);
-    var entity = svg.append("g")
-        .datum( {x: x, y: y, selected: false, kind: "entity",
-                relationships: [],
-                name: ename} )
-        .attr("id",entityID)
-        .attr("class", "entity_instance");
-        //.on("dblclick", null)
-        //.on("click", remove_entity)
-        //.call(drag_entity);
-    entity
-        .append("use")
-        .attr("href","#entity_prototype")
-        .attr("id","r-"+entityID)
-        .attr("x", function(d){ return (d.x) })
-        .attr("y", function(d){ return (d.y) });
-    entity
-        .append("text")
-        .attr("class","ename")
-        .attr("id","t-"+entityID)
-        .attr("x", function(d){ return (d.x) })
-        .attr("y", function(d){ return (d.y) })
-        .attr("text-anchor", "middle")
-        .attr("dominant-baseline", "central")
-        .attr("pointer-events","none")
-        .text( ename ); */
-
     entity_actions(entity);
 
     // Record new entity
     orm.entities[entityID] = entity;
 
     // Create new overlay for entity
-
-    var overlayID = overlay_from_ID(entityID);
-    
-    /*
-    var overlay = svg.append("use")
-       .datum( {x: x, y: y, selected: false} )
-       .attr("href","#entity_overlay_prototype")
-       .attr("class","overlay eoverlay")
-       .attr("id", overlayID)
-       .attr("x", function(d){ return (x) })
-       .attr("y", function(d){ return (y) });*/
-
-    //var ebox = d3.select("#r-"+entity.attr("id"));
     var overlay = overlay_definition(entity,"eoverlay");
+    var overlayID = overlay.attr("id");
 
     overlay_actions(overlay);
-
-    //entity.append(overlay);
     
     // Record overlay
     orm.eoverlays[overlayID] = overlay;
@@ -283,10 +146,7 @@ function entity_actions(entity) {
 }
 
 function overlay_actions(eoverlay) {
-    eoverlay.on("mousedown", eomousedown )
-            .on("hover", function() { 
-                this.attr("fill-opacity", "1.0");
-                console.log("opacity") });
+    eoverlay.on("mousedown", eomousedown );
 }
 
 // Removing entities on click events
@@ -351,28 +211,6 @@ function edragged(event,d,entityID) {
     entity.attr("x", d.x )
           .attr("y", d.y )
           .attr("transform", "translate("+d.dx+","+d.dy+")");
-
-    /* When using defs for entity
-    // Set the new position
-    d.x = event.x;
-    d.y = event.y;
-
-    // Snap
-    d.x = snap(d.x, "x", entityID);
-    d.y = snap(d.y, "y", entityID);
-    
-    // Drag the entity rect
-    // Need transform as long as we can't use prototype
-    var entity = d3.select("#r-"+entityID);
-    entity.attr("x", d.x).attr("y", d.y);
-    d3.select("#t-"+entityID)
-          .attr("x", d.x).attr("y", d.y)
-    //console.log( d3.select("#t-"+entityID) )*/
-
-    /*
-    // Drag the circle overlays
-    d3.select("#"+overlay_from_ID(entityID))
-      .attr("x", d.x).attr("y", d.y);*/
     
     // Drag all connected relations
     for (var n in d.relationships) {
@@ -402,7 +240,6 @@ function eomousedown(event) {
     var m = d3.pointer(event);
     var mousepos = {x: m[0] + d.x - entity_param.width/2, 
                     y: m[1] + d.y - entity_param.height/2};
-    console.log(m, mousepos);
 
     // Center of closest entity overlay
     var eo = closest_eoverlay(mousepos, entityID);

--- a/lib/graph-constructor.js
+++ b/lib/graph-constructor.js
@@ -163,3 +163,57 @@ function remove_from_array(arr, v) {
     }
     return arr;
 }
+
+/* Overlays */
+
+function overlay_definition(object,oclass) {
+    //var width = entity_param.width;
+    //var height = entity_param.height;
+
+    var width = object.attr("width");
+    var height = object.attr("height");
+
+    var d = object.datum();
+    var pd = d3.select("#" + object.attr("parent") ).datum();
+    var overlayID = d.overlay;
+
+    var x = pd.x0 + d.dx;
+    var y = pd.y0;
+
+    var overlay = object.append("g")
+        .attr("id", overlayID)
+        .attr("class","overlay_prototype")
+        .attr("width", width)
+        .attr("height", height)
+        .attr("x", 0)
+        .attr("y", 0)
+        .attr("transform", () => overlay_translate(x,y,width,height) );
+    // Top circle overlay
+    overlay.append("circle")
+        .attr("class","overlay "+oclass)
+        .attr("transform", () => translate(width/2, 0) );
+    // Right circle overlay
+    overlay.append("circle")
+        .attr("class","overlay "+oclass)
+        .attr("transform", () => translate(width, height/2) );
+    // Bottom circle overlay
+    overlay.append("circle")
+        .attr("class","overlay "+oclass)
+        .attr("transform", () => translate(width/2, height) );
+    // Left circle overlay
+    overlay.append("circle")
+        .attr("class","overlay "+oclass)
+        .attr("transform", () => translate(0, height/2) );
+    
+    return overlay;
+}
+
+function overlay_translate(x,y,width,height) {
+    var tx = x - width/2;
+    var ty = y - height/2;
+    return "translate( " + tx + "," + ty + " )"
+}
+
+function translate(x,y) {
+    return "translate( " + x + "," + y + " )"
+}

--- a/lib/graph-constructor.js
+++ b/lib/graph-constructor.js
@@ -1,5 +1,7 @@
 /* Functions that apply across objects */
 
+/* Global definitions */
+
 var orm = {
     entities : {},
     eoverlays : {},
@@ -20,6 +22,8 @@ var tolerance = {
 };
 
 function create_group(defs,width,height,name) {
+
+    // Not used
     
     return defs.append("g")
             .attr("id",name)
@@ -30,7 +34,24 @@ function create_group(defs,width,height,name) {
     
 }
 
+/* General purpose */
+
+function remove_from_array(arr, v) {
+    var index = arr.indexOf(v);
+    if (index > -1) {
+        arr.splice(index, 1);
+    }
+    return arr;
+}
+
+function translate(x,y) {
+    return "translate( " + x + "," + y + " )"
+}
+
 function get_any_object(anyID) {
+
+    // To Do: If we're using this, get rid of default option
+    // Should act as "integrity constraint"
 
     if (orm.entities.hasOwnProperty(anyID)) {
         return orm.entities[anyID];
@@ -41,6 +62,9 @@ function get_any_object(anyID) {
     if (orm.roleboxes.hasOwnProperty(anyID)) {
         return orm.roleboxes[anyID];
     }
+    if (orm.rbgroups.hasOwnProperty(anyID)) {
+        return orm.rbgroups[anyID];
+    }
     return d3.select("#"+anyID);
 }
 
@@ -48,10 +72,13 @@ function get_object_kind(anyID) {
     if ( anyID.includes("rel") ) { return "relationship" }
     if ( anyID.includes("entity") ) { return "entity" }
     if ( anyID.includes("rolebox") &&
-         anyID.includes("r-") ) { return "rolebox" }
+         anyID.includes("r-") &&
+         ! anyID.includes("r-r-") ) { return "rolebox" }
     if ( anyID.includes("rolebox") ) { return "rolebox_group" }
     return ""
 }
+
+/* Drag events */
 
 function closest_overlay(position, anyID,locations=dragevent.locations) {
     if ( is_entityID(anyID) ) {
@@ -156,14 +183,6 @@ function snap( pos, field, anyID ) {
     }
 }
 
-function remove_from_array(arr, v) {
-    var index = arr.indexOf(v);
-    if (index > -1) {
-        arr.splice(index, 1);
-    }
-    return arr;
-}
-
 /* Overlays */
 
 function overlay_definition(object,oclass) {
@@ -212,8 +231,4 @@ function overlay_translate(x,y,width,height) {
     var tx = x - width/2;
     var ty = y - height/2;
     return "translate( " + tx + "," + ty + " )"
-}
-
-function translate(x,y) {
-    return "translate( " + x + "," + y + " )"
 }

--- a/lib/graph-constructor.js
+++ b/lib/graph-constructor.js
@@ -2,17 +2,7 @@
 
 /* Global definitions */
 
-var orm = {
-    entities : {},
-    eoverlays : {},
-    relationships : {},
-    rbgroups : {},
-    roleboxes : {},
-    rboverlays : {},
-    highestEntityID : 0,
-    highestRelID : 0,
-    highestRBID : 0
-};
+var orm;
 
 var dragevent = {locations : ["bottom","right","top","left"]};
 

--- a/lib/parse-svg.js
+++ b/lib/parse-svg.js
@@ -115,6 +115,8 @@ function populate_state() {
         // Populate datum
         orm.roleboxes[rbID].datum( JSON.parse(orm.roleboxes[rbID].attr("json")) );
     }
+
+    set_highest_rolebox_ID()
 }
 
 function populate_actions() {

--- a/lib/parse-svg.js
+++ b/lib/parse-svg.js
@@ -69,7 +69,7 @@ function initialize_globals() {
 function populate_state() {
     
     // Entities
-    var entity_divs = d3.select("svg").selectAll(".entity_instance");
+    var entity_divs = d3.select("svg").selectAll(".entity_prototype");
     for ( k in entity_divs.nodes() ) { 
         // Add entity to entities list
         entityID = entity_divs.nodes()[k].id;

--- a/lib/parse-svg.js
+++ b/lib/parse-svg.js
@@ -107,7 +107,7 @@ function populate_state() {
         orm.rbgroups[rbID].datum( JSON.parse(orm.rbgroups[rbID].attr("json")) );
     }
     // Roleboxes
-    var rolebox_divs = d3.select("svg").selectAll(".rolebox");
+    var rolebox_divs = d3.select("svg").selectAll(".rolebox_prototype");
     for ( k in rolebox_divs.nodes() ) { 
         // Add relationship to relationships list
         rbID = rolebox_divs.nodes()[k].id;

--- a/lib/parse-svg.js
+++ b/lib/parse-svg.js
@@ -13,9 +13,6 @@ function jsonify_data() {
     for ( var entityID in orm.entities ) {
         orm.entities[entityID].attr("json",JSON.stringify( orm.entities[entityID].datum() ));
     }
-    for ( var oentityID in orm.eoverlays ) {
-        orm.eoverlays[oentityID].attr("json",JSON.stringify( orm.eoverlays[oentityID].datum() ));
-    }
     for ( var relID in orm.relationships ) {
         orm.relationships[relID].attr("json",JSON.stringify( orm.relationships[relID].datum() ));
     }
@@ -55,7 +52,6 @@ function upload_svg() {
 function initialize_globals() {
     orm = {
         entities : {},
-        eoverlays : {},
         relationships : {},
         rbgroups : {},
         roleboxes : {},
@@ -76,11 +72,6 @@ function populate_state() {
         orm.entities[entityID] = d3.select("#"+entityID);
         // Populate datum
         orm.entities[entityID].datum( JSON.parse(orm.entities[entityID].attr("json")) );
-        // Add overlay to overlays list
-        oentityID = overlay_from_ID(entityID);
-        orm.eoverlays[oentityID] = d3.select( "#"+oentityID );
-        // Populate datum
-        orm.eoverlays[oentityID].datum( JSON.parse(orm.eoverlays[oentityID].attr("json")) );
     }
 
     set_highest_entity_ID();
@@ -126,10 +117,6 @@ function populate_actions() {
 
     for ( var entityID in orm.entities ) {
         entity_actions( orm.entities[entityID] );
-    }
-
-    for (var oentityID in orm.eoverlays ) {
-        overlay_actions( orm.eoverlays[oentityID] );
     }
 
     for ( var relID in orm.relationships ) {

--- a/lib/rolebox-constructor.js
+++ b/lib/rolebox-constructor.js
@@ -152,9 +152,10 @@ function add_rolebox(rbgroup) {
     rbname = "rolebox " + boxcount.toString() ;
 
     // Rolebox visualization
-    rbgroup.append("rect")
+    rbgroup.append("g")
            .datum( {x : d.x + boxcount * rb_param.width,
                     y : d.y,
+                    dx : boxcount * rb_param.width, // this is used for the overlay definition
                     kind : "rolebox",
                     name : rbname,
                     parent: rbID,
@@ -165,14 +166,27 @@ function add_rolebox(rbgroup) {
            .attr("class","rolebox")
            .attr("id", boxID)
            .attr("parent", rbID)
-           .attr("transform", "translate( -" + rb_param.width/2 + 
-                                        " -" + rb_param.height/2 + " )")
            .attr("x", function(){
                 return d.x0 + boxcount * rb_param.width;
            })
            .attr("y", function(){
                 return d.y0;
-           });
+           })
+           .attr("width", rb_param.width)
+           .attr("height", rb_param.height)
+           .append("rect")
+                .attr("class","rolebox")
+                .attr("id", "r-" + boxID)
+                .attr("width", rb_param.width)
+                .attr("height", rb_param.height)
+                .attr("x", function(){
+                            return d.x0 + boxcount * rb_param.width;
+                    })
+                .attr("y", function(){
+                            return d.y0;
+                    })
+                .attr("transform", "translate( -" + rb_param.width/2 + 
+                                                " -" + rb_param.height/2 + " )");
 
     var rbox = d3.select("#"+boxID);
     // Add rolebox overlay
@@ -199,12 +213,16 @@ function add_overlay(rbox) {
     var rbgroup = d3.select("#"+rbox.attr("parent"));
     var overlayID = rbox.datum().overlay;
 
+    /*
     rbgroup.append("use")
        .attr("href","#rolebox_overlay_prototype")
        .attr("id", overlayID)
        .attr("rbox", rbox.attr("id") )
        .attr("x", rbox.attr("x"))
-       .attr("y", rbox.attr("y") );
+       .attr("y", rbox.attr("y") );*/
+    
+    var overlay = overlay_definition(rbox,"rboverlay");
+    overlay.attr("rbox", rbox.attr("id") );
 }
 
 function set_rolebox_display_name(rbgroup) {
@@ -395,12 +413,17 @@ function rbomousedown(event) {
     
     event.stopPropagation();
 
+    // Get rolebox
+    var boxID = d3.select(this).attr("rbox");
+    var d = orm.roleboxes[boxID].datum();
+
     // current pointer position
     var m = d3.pointer(event);
-    var mousepos = {x: m[0], y: m[1]};
+    //var mousepos = {x: m[0], y: m[1]};
+    var mousepos = {x: m[0] + d.x - rb_param.width/2, 
+                    y: m[1] + d.y - rb_param.height/2};
 
     // Center of closest entity overlay
-    var boxID = d3.select(this).attr("rbox");
     var rbo = closest_rboverlay(mousepos, boxID);
 
     // We're changing globals here. They get set back on mouseup.

--- a/lib/rolebox-constructor.js
+++ b/lib/rolebox-constructor.js
@@ -78,20 +78,20 @@ function rolebox_prototype(defs) {
     var addo = create_group(defs,oboxsize,oboxsize,"rolebox_add_prototype");
     addo.attr("transform", "translate( " + transx + " -" + transy + " )");
     addo.append("path")
-        .attr("d", plusPath(osize))
+        .attr("d", plusPath({x:0,y:0},osize))
         .attr("class","rbadd");
     
 }
 
-function plusPath(size) {
+function plusPath(position, size) {
 
     // Draw the plus sign overlay for adding new roleboxes
     var hsize = size/2;
     return [
-        "M", 0, ",", -hsize,
-        "L", 0, ",", hsize,
-        "M", -hsize, ",", 0,
-        "L", hsize, ",", 0,
+        "M", position.x, ",", position.y-hsize,
+        "L", position.x, ",", position.y+hsize,
+        "M", position.x-hsize, ",", position.y,
+        "L", position.x+hsize, ",", position.y,
         "Z"
     ].join("");
 }
@@ -122,17 +122,26 @@ function draw_rolebox(x,y) {
         .attr("dominant-baseline", "center")
         .attr("pointer-events","none")
         .text( function(d){ return d.name } );
-    
-    add_rolebox(rbgroup);
 
     // Add overlay used for adding roleboxes to the group
     var addrbID = "add-"+rbID;
-    rbgroup.append("use")
+    /*rbgroup.append("use")
         .datum( {x: x, y: y, selected: false} )
         .attr("href","#rolebox_add_prototype")
         .attr("id", addrbID)
         .attr("x", function(d){ return (x) })
-        .attr("y", function(d){ return (y) });
+        .attr("y", function(d){ return (y) });*/
+    var osize = rb_param.height;
+    rbgroup
+        .append("path")
+        .attr("d", function(d) { return plusPath(d,osize) } )
+        .attr("class","rbadd")
+        .attr("id", addrbID)
+        .attr("x", function(d){ return (d.x0 - rb_param.width) })
+        .attr("y", function(d){ return (d.y0) })
+        .attr("transform", "translate( -" + rb_param.width + ", 0 )");
+
+    add_rolebox(rbgroup);
 
     rolebox_group_actions(rbgroup);
 

--- a/lib/rolebox-constructor.js
+++ b/lib/rolebox-constructor.js
@@ -158,6 +158,7 @@ function add_rolebox(rbgroup) {
                     kind : "rolebox",
                     name : rbname,
                     parent: rbID,
+                    overlay: "o"+boxID,
                     entity: null, 
                     relationships : [],
                     selected : false } )
@@ -173,11 +174,11 @@ function add_rolebox(rbgroup) {
                 return d.y0;
            });
 
-    // Add rolebox actions
     var rbox = d3.select("#"+boxID);
-    rolebox_actions( rbox );
     // Add rolebox overlay
     add_overlay( rbox );
+    // Add rolebox actions
+    rolebox_actions( rbox );
     // Record rolebox
     orm.roleboxes[ boxID ] = rbox;
 
@@ -196,18 +197,14 @@ function add_rolebox(rbgroup) {
 function add_overlay(rbox) {
 
     var rbgroup = d3.select("#"+rbox.attr("parent"));
-    var gd = rbgroup.datum();
-    var boxcount = gd.boxes.length - 1; // rolebox already added so -1
-    var rbID = rbgroup.attr("id");
-    var overlayID = "or-" + boxcount.toString() + "-" + rbID;
+    var overlayID = rbox.datum().overlay;
 
     rbgroup.append("use")
        .attr("href","#rolebox_overlay_prototype")
        .attr("id", overlayID)
        .attr("rbox", rbox.attr("id") )
        .attr("x", rbox.attr("x"))
-       .attr("y", rbox.attr("y") )
-       .on("mousedown", rbomousedown );;
+       .attr("y", rbox.attr("y") );
 }
 
 function set_rolebox_display_name(rbgroup) {
@@ -328,6 +325,8 @@ function bubble_relationships(rbgroup) {
 function rolebox_actions(rbox) {
     rbox
         .on("click", remove_rolebox);
+    d3.select("#"+rbox.datum().overlay)
+        .on("mousedown", rbomousedown );
 }
 
 function remove_rolebox(event,d) {

--- a/lib/rolebox-constructor.js
+++ b/lib/rolebox-constructor.js
@@ -79,7 +79,7 @@ function rolebox_prototype(defs) {
     addo.attr("transform", "translate( " + transx + " -" + transy + " )");
     addo.append("path")
         .attr("d", plusPath(osize))
-        .attr("class","overlay rbadd");
+        .attr("class","rbadd");
     
 }
 

--- a/lib/rolebox-constructor.js
+++ b/lib/rolebox-constructor.js
@@ -1,22 +1,35 @@
 /*
     Everything related to roleboxes
+
+    This file defines roleboxes, data associated with how they are represented and
+    connected to other objects, and actions they can perform, such as on drag and 
+    click events.
 */
 
-/***** Rolebox property definitions *****/
+/***** Global definitions *****/
 
+// Rolebox appearance and behavior
+// TO DO: Pull from css
 var rb_param = {
     width : 50,
     height : 18,
     snapTolerance : 5
 };
+
+// Distance tolerances for snap and link events
 var tolerance;
 tolerance.link["rolebox"] = rb_param.width ;
 tolerance.snap["rolebox"] = rb_param.snapTolerance ;
 tolerance.snap["rolebox_group"] = rb_param.snapTolerance ;
 
-var svg;
-var orm;
-var dragevent;
+// Graph variables
+var svg; // Defined in svg-constructor
+var orm; // Defined in graph-constructor
+var dragevent; // Defined in graph-constructor
+
+/***** END Global definitions *****/
+
+/***** Rolebox IDS *****/
 
 function generate_roleboxID() {
     rbID = "id-rolebox-" + orm.highestRBID.toString();
@@ -42,9 +55,14 @@ function set_highest_rolebox_ID() {
     }
 }
 
+/***** END Entity IDs *****/
+
+/*****  Drawing roleboxes *****/
+
+/*
 function rolebox_prototype(defs) {
 
-    /* Define the look of a rolebox */
+    // Define the look of a rolebox 
 
     var width = rb_param.width;
     var height = rb_param.height;
@@ -82,6 +100,7 @@ function rolebox_prototype(defs) {
         .attr("class","rbadd");
     
 }
+*/
 
 function plusPath(position, size) {
 
@@ -141,11 +160,12 @@ function draw_rolebox(x,y) {
         .attr("y", function(d){ return (d.y0) })
         .attr("transform", "translate( -" + rb_param.width + ", 0 )");
 
+    // Add rolebox to group, including overlays and actions
     add_rolebox(rbgroup);
 
     rolebox_group_actions(rbgroup);
 
-    // Record new entity
+    // Record new rolebox group
     orm.rbgroups[rbID] = rbgroup;
 
 }
@@ -199,7 +219,8 @@ function add_rolebox(rbgroup) {
 
     var rbox = d3.select("#"+boxID);
     // Add rolebox overlay
-    add_overlay( rbox );
+    var overlay = overlay_definition(rbox, "rboverlay");
+    overlay.attr("rbox", rbox.attr("id") );
     // Add rolebox actions
     rolebox_actions( rbox );
     // Record rolebox
@@ -217,22 +238,19 @@ function add_rolebox(rbgroup) {
     }
 }
 
+/*
 function add_overlay(rbox) {
 
     var rbgroup = d3.select("#"+rbox.attr("parent"));
     var overlayID = rbox.datum().overlay;
 
-    /*
     rbgroup.append("use")
        .attr("href","#rolebox_overlay_prototype")
        .attr("id", overlayID)
        .attr("rbox", rbox.attr("id") )
        .attr("x", rbox.attr("x"))
-       .attr("y", rbox.attr("y") );*/
-    
-    var overlay = overlay_definition(rbox,"rboverlay");
-    overlay.attr("rbox", rbox.attr("id") );
-}
+       .attr("y", rbox.attr("y") );
+}*/
 
 function set_rolebox_display_name(rbgroup) {
 
@@ -259,7 +277,9 @@ function set_rolebox_display_name(rbgroup) {
         });
 }
 
-/* Rolebox actions */
+/***** END Drawing roleboxes *****/
+
+/***** Rolebox actions *****/
 
 function rolebox_group_actions(rbgroup) {
 
@@ -280,6 +300,74 @@ function rolebox_group_actions(rbgroup) {
         .on("click", function() { add_rolebox(rbgroup); });
 
 }
+
+function rolebox_actions(rbox) {
+    rbox
+        .on("click", remove_rolebox);
+    d3.select("#"+rbox.datum().overlay)
+        .on("mousedown", rbomousedown );
+}
+
+/* Remove rolebox */
+
+function remove_rolebox(event,d) {
+    if (event.ctrlKey) {
+        delete_rolebox( d3.select(this) );
+    }
+}
+
+function delete_rolebox(rbox) {
+
+    // Get parent group of rolebox
+    rbgroup = d3.select("#"+rbox.attr("parent"));
+    gd = rbgroup.datum();
+
+    // Only remove right-most
+    if ( rbox.attr("id") != gd.boxes[gd.boxes.length -1] ) { return }
+
+    // Remove relationships
+    //rels = gd.rbdata[rbox.attr("id")].relationships;
+    rels = rbox.datum().relationships;
+    for ( n in rels ) {
+        // Delete the relationships
+        delete_relationship(orm.relationships[ rels[n] ]);
+        // Remove relationship reference from parent
+        gd.relationships = remove_from_array( gd.relationships, rels[n] );
+    }
+
+    // Remove box reference from parent
+    rboxID = rbox.attr("id");
+    gd.boxes = remove_from_array( gd.boxes, rboxID );
+
+    // Remove box reference from records
+    delete orm.roleboxes[ rboxID ];
+
+    // Remove the rolebox visualization
+    rbox.remove();
+    set_rolebox_display_name(rbgroup);
+    
+    // Remove the rolebox from records
+    var x = gd.x;
+    var y = gd.y;
+    if ( gd.boxes.length == 0 ) {
+        // Remove group reference
+        delete orm.rbgroups[ rbgroup.attr("id") ];
+        // Remove group
+        rbgroup
+            .transition()
+            .duration(500)
+            .attr("transform", "translate(" + x + "," + y + ") scale(0)")
+            .remove();
+    } else {
+        // For the new right-most box, update eligible overlays
+        set_eligible_overlays_rolebox( gd.boxes[gd.boxes.length - 1] );
+    }
+
+    // Update ORM
+    parse_orm();
+}
+
+/*****  Drag control for the rolebox group *****/
 
 function rbdragstarted(event,d) {
     //event.sourceEvent.stopPropagation();
@@ -322,8 +410,10 @@ function rbdragged(event,d,rbgroupID) {
 }
 
 function set_rolebox_positions(rbgroup, x, y) {
+    // For each rolebox datum, set it's x and y
+    // based on rolebox group position.
     var xval = 0;
-    var rbox, n;
+    var n;
     var rboxes = rbgroup.datum().boxes;
     for ( n in rboxes ) {
         d = d3.select("#"+rboxes[n]).datum();
@@ -347,74 +437,7 @@ function bubble_relationships(rbgroup) {
     gd.relationships = rellist;
 }
 
-/* Remove rolebox */
-
-function rolebox_actions(rbox) {
-    rbox
-        .on("click", remove_rolebox);
-    d3.select("#"+rbox.datum().overlay)
-        .on("mousedown", rbomousedown );
-}
-
-function remove_rolebox(event,d) {
-    if (event.ctrlKey) {
-        delete_rolebox( d3.select(this) );
-    }
-}
-
-function delete_rolebox(rbox) {
-
-    // Get parent group of rolebox
-    rbgroup = d3.select("#"+rbox.attr("parent"));
-    gd = rbgroup.datum();
-
-    // Only remove right-most
-    if ( rbox.attr("id") != gd.boxes[gd.boxes.length -1] ) { return }
-
-    // Remove relationships
-    //rels = gd.rbdata[rbox.attr("id")].relationships;
-    rels = rbox.datum().relationships;
-    for ( n in rels ) {
-        // Delete the relationships
-        delete_relationship(orm.relationships[ rels[n] ]);
-        // Remove relationship reference from parent
-        gd.relationships = remove_from_array( gd.relationships, rels[n] );
-    }
-
-    // Remove box reference from parent
-    rboxID = rbox.attr("id");
-    gd.boxes = remove_from_array( gd.boxes, rboxID );
-
-    // Remove box reference from records
-    delete orm.roleboxes[ rboxID ];
-
-    // Remove the rolebox visualization
-    // Remove overlay part
-    //d3.select( "#" + overlay_from_ID(entityID) ).remove();
-    // Remove box part
-    rbox.remove();
-    set_rolebox_display_name(rbgroup);
-    
-    // Remove the rolebox from records
-    var x = gd.x;
-    var y = gd.y;
-    if ( gd.boxes.length == 0 ) {
-        // Remove group reference
-        delete orm.rbgroups[ rbgroup.attr("id") ];
-        // Remove group
-        rbgroup
-            .transition()
-            .duration(500)
-            .attr("transform", "translate(" + x + "," + y + ") scale(0)")
-            .remove();
-    } else {
-        // For the new right-most box, update eligible overlays
-        set_eligible_overlays_rolebox( gd.boxes[gd.boxes.length - 1] );
-    }
-
-    // Update ORM
-    parse_orm();
-}
+/***** END Drag control for the rolebox group *****/
 
 /* On mouse down for the rolebox overlay circles */
 
@@ -540,3 +563,7 @@ function set_eligible_overlays_rolebox(boxID) {
         set_eligible_overlays( d3.select("#"+rels[n]) );
     }
 }
+
+/* END On mouse up for the rolebox overlay circles */
+
+/***** END Rolebox actions *****/

--- a/lib/rolebox-constructor.js
+++ b/lib/rolebox-constructor.js
@@ -163,7 +163,7 @@ function add_rolebox(rbgroup) {
                     entity: null, 
                     relationships : [],
                     selected : false } )
-           .attr("class","rolebox")
+           .attr("class","rolebox_prototype")
            .attr("id", boxID)
            .attr("parent", rbID)
            .attr("x", function(){

--- a/lib/svg-constructor.js
+++ b/lib/svg-constructor.js
@@ -10,7 +10,7 @@ function prototypes() {
     // entities.
 
     var defs = svg.append("defs");
-    entity_prototype(defs);
+    //entity_prototype(defs);
     //relationships_prototype(defs);
     rolebox_prototype(defs);
 }

--- a/lib/svg-constructor.js
+++ b/lib/svg-constructor.js
@@ -12,7 +12,7 @@ function prototypes() {
     var defs = svg.append("defs");
     //entity_prototype(defs);
     //relationships_prototype(defs);
-    rolebox_prototype(defs);
+    //rolebox_prototype(defs);
 }
 
 function svg_actions(mysvg) {
@@ -38,7 +38,7 @@ window.onload = function() {
                 .attr("width", "90vw")
                 .attr("height", "50vh");
     // Define prototype objects
-    prototypes();
+    //prototypes();
 
     // Draw an initial entity
     draw_entity(100,100);

--- a/lib/svg-constructor.js
+++ b/lib/svg-constructor.js
@@ -2,6 +2,7 @@
     Constructing the svg and defining prototype objects
 */
 
+var orm;
 var svg;
 var svgscale;
 
@@ -39,8 +40,9 @@ function set_viewbox(svgscale) {
 
 window.onload = function() {
 
-    svgscale = 250;
+    initialize_globals();
 
+    svgscale = 250;
     //Create SVG element
     svg = d3.select("#canvas")
                 .append("svg")

--- a/lib/svg-constructor.js
+++ b/lib/svg-constructor.js
@@ -3,8 +3,11 @@
 */
 
 var svg;
+var svgscale;
 
 function prototypes() {
+
+    // Not used
 
     // Create the svg and populate with prototype object for
     // entities.
@@ -29,19 +32,30 @@ function svg_actions(mysvg) {
     });
 }
 
+function set_viewbox(svgscale) {
+    return "-" + svgscale/2 + ", -" + svgscale/2 +
+           ", " + svgscale + ", " + svgscale;
+}
+
 window.onload = function() {
+
+    svgscale = 250;
 
     //Create SVG element
     svg = d3.select("#canvas")
                 .append("svg")
                 .attr("id","canvas-svg")
-                .attr("width", "90vw")
-                .attr("height", "50vh");
+                .attr("width", "100%")
+                .attr("height", "100%")
+                //.attr("preserveAspectRatio","none")
+                .attr("viewBox", () => set_viewbox(svgscale));
+
+    console.log(svg.attr("width"))
     // Define prototype objects
     //prototypes();
 
     // Draw an initial entity
-    draw_entity(100,100);
+    draw_entity(0,0);
 
     // Actions related to interaction with the svg
     svg_actions(svg);

--- a/lib/svg-constructor.js
+++ b/lib/svg-constructor.js
@@ -50,15 +50,14 @@ window.onload = function() {
                 //.attr("preserveAspectRatio","none")
                 .attr("viewBox", () => set_viewbox(svgscale));
 
-    console.log(svg.attr("width"))
     // Define prototype objects
     //prototypes();
 
-    // Draw an initial entity
-    draw_entity(0,0);
-
     // Actions related to interaction with the svg
     svg_actions(svg);
+
+    // Draw an initial entity
+    draw_entity(0,0);
 
     // Button actions
     d3.select("#downloadSvgButton")

--- a/style/orm-style.css
+++ b/style/orm-style.css
@@ -39,6 +39,21 @@ svg {
     transform-origin: center;
 }
 
+/* All objects */
+
+.shadowed {
+    filter: drop-shadow(5px 5px 2px rgb(0,0,0,0.4));
+}
+
+.overlay {
+    fill: transparent;
+}
+
+.overlay:hover {
+    fill: rgb(129, 218, 240, 0.5);
+    cursor: pointer;
+}
+
 /* Entities */
 
 .entity {
@@ -53,23 +68,6 @@ svg {
     font-size: 20px;
     font-family: "Montserrat Light";
     cursor: grab;
-}
-
-.shadowed {
-    filter: drop-shadow(5px 5px 2px rgb(0,0,0,0.4));
-}
-
-.overlay {
-    fill: rgb(129, 218, 240, 0.5);
-    fill-opacity: 0;
-    opacity: 0;
-    display: block;
-    cursor: pointer;
-}
-
-.overlay:hover {
-    fill-opacity: 1;
-    opacity: 1;
 }
 
 .eoverlay {
@@ -100,8 +98,15 @@ svg {
 }
 
 .rbadd {
-    stroke-width: 4;
-    stroke: rgb(129, 218, 240,0.8);
+    stroke: rgb(129, 218, 240,1);
+    opacity: 0.0;
+    cursor: pointer;
+}
+
+.rbadd:hover {
+    stroke-width: 6;
+    opacity: 0.7;
+    cursor: pointer ;
 }
 
 /* Relationships */

--- a/style/orm-style.css
+++ b/style/orm-style.css
@@ -46,12 +46,12 @@ svg {
 }
 
 .overlay {
-    fill: transparent;
+    fill: rgb(129, 218, 240, 0.0);
+    cursor: pointer;
 }
 
 .overlay:hover {
     fill: rgb(129, 218, 240, 0.5);
-    cursor: pointer;
 }
 
 /* Entities */
@@ -95,18 +95,19 @@ svg {
 
 .rboverlay {
     r: 8px;
+    stroke-width: 0;
 }
 
+
 .rbadd {
-    stroke: rgb(129, 218, 240,1);
+    stroke: rgb(129, 218, 240,0.8);
+    stroke-width: 6;
     opacity: 0.0;
     cursor: pointer;
 }
 
 .rbadd:hover {
-    stroke-width: 6;
-    opacity: 0.7;
-    cursor: pointer ;
+    opacity: 1.0;
 }
 
 /* Relationships */


### PR DESCRIPTION
This PR removes dependencies on defs. This was necessary because of inconsistent cross-browser behavior of `<use>` elements on hover events. (And probably both FF and Chrome are "wrong" in different ways.)